### PR TITLE
Fix for multi-process update

### DIFF
--- a/SpotifyPauser/SpotifyPauser/Program.cs
+++ b/SpotifyPauser/SpotifyPauser/Program.cs
@@ -126,8 +126,14 @@ namespace SpotifyAutoPauser
             if (!IsSpotifyRunning()) return null;
             Process[] procs = GetSpotifyProcesses();
 
-            // I'm only expecting there to be one...
-            return procs[0].MainWindowTitle;
+			// seems like there are usually multiple Spotify processes - find the one with an actual title
+			string title = "";
+			foreach (Process proc in procs) {
+				if (proc.MainWindowTitle.Length > 0) {
+					title = proc.MainWindowTitle;
+				}		
+			}
+			return title;
         }
 
         private static bool IsSpotifyPlaying()


### PR DESCRIPTION
This fixes issue #5.

The problem seems to be that Spotify now runs in multiple processes. I don't know if that was always the case, or if in the past the first process in the list returned by `Process.GetProcessesByName("spotify")` was always the one with the title.

This will loop over all the Spotify process and pick the first one with an actual title. At least on my machine (Win 8.1), this always seems to work.